### PR TITLE
Changed Venezuela's currency code from VEF to VES

### DIFF
--- a/countriesData.js
+++ b/countriesData.js
@@ -3048,7 +3048,7 @@ module.exports = [
     "countryNameEn": "Venezuela (Bolivarian Republic of)",
     "countryNameLocal": "Venezuela",
     "countryCode": "VE",
-    "currencyCode": "VEF",
+    "currencyCode": "VES",
     "currencyNameEn": "",
     "tinType": "RIF",
     "tinName": "Registro de Informacion Fiscal",


### PR DESCRIPTION
Fixes #6 