### PR TITLE
feat: exports CountryProperty enum & update customArray signature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 // by jakeisnt, Feb. 2022
 
 declare module 'country-codes-list' {
-  enum CountryProperty {
+  export enum CountryProperty {
     countryNameEn = 'countryNameEn',
     countryNameLocal = 'countryNameLocal',
     countryCode = 'countryCode',
@@ -19,43 +19,49 @@ declare module 'country-codes-list' {
   }
 
   type CountryData = {
-    [CountryProperty.countryNameEn]: string,
-    [CountryProperty.countryNameLocal]: string,
-    [CountryProperty.countryCode]: string,
-    [CountryProperty.currencyCode]: string,
-    [CountryProperty.currencyNameEn]: string,
-    [CountryProperty.tinType]: string,
-    [CountryProperty.tinName]: string,
-    [CountryProperty.officialLanguageCode]: string,
-    [CountryProperty.officialLanguageNameEn]: string,
-    [CountryProperty.officialLanguageNameLocal]: string,
-    [CountryProperty.countryCallingCode]: string,
-    [CountryProperty.region]: string,
-    [CountryProperty.flag]: string,
-  };
+    [CountryProperty.countryNameEn]: string
+    [CountryProperty.countryNameLocal]: string
+    [CountryProperty.countryCode]: string
+    [CountryProperty.currencyCode]: string
+    [CountryProperty.currencyNameEn]: string
+    [CountryProperty.tinType]: string
+    [CountryProperty.tinName]: string
+    [CountryProperty.officialLanguageCode]: string
+    [CountryProperty.officialLanguageNameEn]: string
+    [CountryProperty.officialLanguageNameLocal]: string
+    [CountryProperty.countryCallingCode]: string
+    [CountryProperty.region]: string
+    [CountryProperty.flag]: string
+  }
 
-  type Filter<T> = (element: T, index: number, array: T[]) => T[];
+  type Filter<T> = (element: T, index: number, array: T[]) => T[]
 
   type CustomArraySettings = {
-    sortDataBy?: CountryProperty,
-    sortBy?: any,
-    filter?: Filter<CountryData>,
-  };
+    sortDataBy?: CountryProperty
+    sortBy?: any
+    filter?: Filter<CountryData>
+  }
 
-  export function all(): CountryData[];
+  export function all(): CountryData[]
 
-  export function filter(countryProperty: CountryProperty, value: string): CountryData[];
+  export function filter(
+    countryProperty: CountryProperty,
+    value: string,
+  ): CountryData[]
 
-  export function findOne(countryProperty: CountryProperty, value: string): CountryData;
+  export function findOne(
+    countryProperty: CountryProperty,
+    value: string,
+  ): CountryData
 
   export function customArray(
-    fields?: { name?: string, value?: string },
-    settings?: CustomArraySettings
-  ): string[];
+    fields?: Record<string, string>,
+    settings?: CustomArraySettings,
+  ): Record<string, string>[]
 
   export function customList(
     key?: CountryProperty,
     label?: string,
     settings?: CustomArraySettings,
-  ): { [CountryProperty]: string };
+  ): { [key in CountryProperty]: string }
 }


### PR DESCRIPTION
the export of the CountryProperty enum is a quality of life improvements that allows developers to use that to denote types and improve type-safety when using this library

also included as a more flexible suggestion for the signature for `customArray' this has been tested against the current released package and works as expected