### PR TITLE
fix: enum CountryProperties is not defined at runtime in TypeScript

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,5 +84,24 @@ module.exports = {
     })
 
     return finalObject
+  },
+  
+  /**
+   * enum used at runtime to access country properties
+   */
+  CountryProperty: {
+    countryNameEn: 'countryNameEn',
+    countryNameLocal: 'countryNameLocal',
+    countryCode: 'countryCode',
+    currencyCode: 'currencyCode',
+    currencyNameEn: 'currencyNameEn',
+    tinType: 'tinType',
+    tinName: 'tinName',
+    officialLanguageCode: 'officialLanguageCode',
+    officialLanguageNameEn: 'officialLanguageNameEn',
+    officialLanguageNameLocal: 'officialLanguageNameLocal',
+    countryCallingCode: 'countryCallingCode',
+    region: 'region',
+    flag: 'flag',
   }
 }


### PR DESCRIPTION
Fixes #36 . Now you can write the following TypeScript code without runtime error:
```
import countries, { CountryProperty } from "country-codes-list";

function findCountry(code: string) {
 return countries.findOne(CountryProperty.countryCode, code);
}
```