### PR TITLE
fix: replace CountryProperty enum by union

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,37 +2,24 @@
 // by jakeisnt, Feb. 2022
 
 declare module 'country-codes-list' {
-  export enum CountryProperty {
-    countryNameEn = 'countryNameEn',
-    countryNameLocal = 'countryNameLocal',
-    countryCode = 'countryCode',
-    currencyCode = 'currencyCode',
-    currencyNameEn = 'currencyNameEn',
-    tinType = 'tinType',
-    tinName = 'tinName',
-    officialLanguageCode = 'officialLanguageCode',
-    officialLanguageNameEn = 'officialLanguageNameEn',
-    officialLanguageNameLocal = 'officialLanguageNameLocal',
-    countryCallingCode = 'countryCallingCode',
-    region = 'region',
-    flag = 'flag',
+
+  export type CountryData = {
+    countryNameEn: string
+    countryNameLocal: string
+    countryCode: string
+    currencyCode: string
+    currencyNameEn: string
+    tinType: string
+    tinName: string
+    officialLanguageCode: string
+    officialLanguageNameEn: string
+    officialLanguageNameLocal: string
+    countryCallingCode: string
+    region: string
+    flag: string
   }
 
-  type CountryData = {
-    [CountryProperty.countryNameEn]: string
-    [CountryProperty.countryNameLocal]: string
-    [CountryProperty.countryCode]: string
-    [CountryProperty.currencyCode]: string
-    [CountryProperty.currencyNameEn]: string
-    [CountryProperty.tinType]: string
-    [CountryProperty.tinName]: string
-    [CountryProperty.officialLanguageCode]: string
-    [CountryProperty.officialLanguageNameEn]: string
-    [CountryProperty.officialLanguageNameLocal]: string
-    [CountryProperty.countryCallingCode]: string
-    [CountryProperty.region]: string
-    [CountryProperty.flag]: string
-  }
+  export type CountryProperty = keyof CountryData
 
   type Filter<T> = (element: T, index: number, array: T[]) => T[]
 


### PR DESCRIPTION
The current version of the library does not work with TypeScript. The issue is demonstrated in this [sandox](https://codesandbox.io/p/devbox/peaceful-mahavira-gv7jlx?layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clpk7vejp00063b6exgyjtbje%2522%252C%2522sizes%2522%253A%255B70%252C30%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clpk7vejo00023b6et1n7u1bs%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clpk7vejo00043b6e1pjkqzlv%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clpk7vejp00053b6e93t6hzjx%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B60%252C40%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clpk7vejo00023b6et1n7u1bs%2522%253A%257B%2522id%2522%253A%2522clpk7vejo00023b6et1n7u1bs%2522%252C%2522tabs%2522%253A%255B%255D%257D%252C%2522clpk7vejp00053b6e93t6hzjx%2522%253A%257B%2522id%2522%253A%2522clpk7vejp00053b6e93t6hzjx%2522%252C%2522activeTabId%2522%253A%2522clpk82n85010h3b6ea5ym8xom%2522%252C%2522tabs%2522%253A%255B%257B%2522type%2522%253A%2522SANDBOX_INFO%2522%252C%2522id%2522%253A%2522clpk82n85010h3b6ea5ym8xom%2522%252C%2522mode%2522%253A%2522permanent%2522%257D%255D%257D%252C%2522clpk7vejo00043b6e1pjkqzlv%2522%253A%257B%2522id%2522%253A%2522clpk7vejo00043b6e1pjkqzlv%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clpk7vejo00033b6ewgl4fcd4%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TASK_LOG%2522%252C%2522taskId%2522%253A%2522start%2522%257D%255D%252C%2522activeTabId%2522%253A%2522clpk7vejo00033b6ewgl4fcd4%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D). The problem is that `index.d.ts` exposes an enum type which is used as param in functions like `findOne`. However, this enum is not backed by any object in JS, so the code compiles but breaks at runtime. 

One simple way to fix this, it's by exporting a constant object for the enum (done in #40). However, removing this enum and replacing it with a union type is a more elegant solution which does not need to change the JS implementation. 