### PR TITLE
ci: auto-create GitHub Release on tag publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,10 +5,11 @@ on:
     tags:
       - "v*"
 
-# Required for Trusted Publishing (OIDC) — no NPM_TOKEN needed.
+# id-token: write is required for Trusted Publishing (OIDC) — no NPM_TOKEN needed.
+# contents: write lets the workflow create the GitHub Release for the tag.
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
   build-and-publish:
@@ -34,3 +35,18 @@ jobs:
       # Auth is via OIDC; provenance is generated automatically on public repos.
       - name: Publish package
         run: npm publish
+
+      # Create the GitHub Release for this tag (skips if it already exists,
+      # e.g. on a re-run). Notes are auto-generated from merged PRs/commits.
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
+            echo "Release ${{ github.ref_name }} already exists, skipping."
+          else
+            gh release create "${{ github.ref_name }}" \
+              --title "${{ github.ref_name }}" \
+              --generate-notes \
+              --verify-tag
+          fi


### PR DESCRIPTION
Automates the GitHub Release step so it no longer has to be done by hand (v2.1.0 was created manually to fill the gap after v2.0.0).

## What
After a successful `npm publish`, the workflow now creates the matching **GitHub Release** for the pushed tag, with notes auto-generated from merged PRs/commits.

- Bumps `permissions.contents` from `read` to `write` (needed to create releases).
- Adds a `Create GitHub Release` step using `gh release create ... --generate-notes --verify-tag`.
- **Idempotent:** skips creation if the release already exists (e.g. on a workflow re-run), so re-runs never fail on this step.

## Result
From now on, a single `git push` of a `v*` tag will: publish to npm (via Trusted Publishing / OIDC) **and** create the GitHub Release — keeping the Releases page in sync automatically.

## Notes
No change to the publish trigger or to Trusted Publishing. Uses the built-in `GITHUB_TOKEN` (`github.token`); no extra secrets.