### PR TITLE
fix: remove Netherlands Antilles (AN), dissolved in 2010

### DIFF
--- a/src/countriesData.ts
+++ b/src/countriesData.ts
@@ -510,7 +510,7 @@ const countriesData: CountryData[] = [
     officialLanguageNameLocal: "Nederlands, Vlaams",
     countryCallingCode: "5997",
     areaCodes: [],
-    region: "Unknown",
+    region: "South/Latin America",
     flag: "🇧🇶",
   },
   {
@@ -841,7 +841,7 @@ const countriesData: CountryData[] = [
     officialLanguageNameLocal: "Nederlands, Vlaams",
     countryCallingCode: "599",
     areaCodes: [],
-    region: "Unknown",
+    region: "South/Latin America",
     flag: "🇨🇼",
   },
   {
@@ -3207,7 +3207,7 @@ const countriesData: CountryData[] = [
     officialLanguageNameLocal: "Nederlands, Vlaams",
     countryCallingCode: "1721",
     areaCodes: [],
-    region: "Unknown",
+    region: "South/Latin America",
     flag: "🇸🇽",
   },
   {
@@ -4313,22 +4313,6 @@ const countriesData: CountryData[] = [
     countryCallingCode: "383",
     region: "Europe",
     flag: "🇽🇰",
-  },
-  {
-    countryNameEn: "Netherlands Antilles",
-    countryNameLocal: "Nederlandse Antillen",
-    countryCode: "AN",
-    countryCodeAlpha3: "ANT",
-    currencyCode: "ANG",
-    currencyNameEn: "Netherlands Antillean guilder",
-    tinType: "",
-    tinName: "",
-    officialLanguageCode: "nl",
-    officialLanguageNameEn: "Dutch, Flemish",
-    officialLanguageNameLocal: "Nederlands, Vlaams",
-    countryCallingCode: "599",
-    region: "Europe",
-    flag: "🇧🇶",
   },
 ];
 

--- a/tests/withdrawnCountries.test.ts
+++ b/tests/withdrawnCountries.test.ts
@@ -1,0 +1,82 @@
+import * as countryCodes from "../src/index";
+
+const all = countryCodes.all();
+
+/**
+ * ISO 3166-1 alpha-2 codes that have been formally deleted from the standard,
+ * with the entities that replaced them. None of these should appear in the
+ * dataset — consumers rendering a country picker must not be able to select a
+ * state that no longer exists.
+ * https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Deleted_codes
+ */
+const DELETED_ALPHA2: Record<string, string> = {
+  AN: "Netherlands Antilles, dissolved 2010-10-10",
+  CS: "Serbia and Montenegro, dissolved 2006",
+  YU: "Yugoslavia",
+  DD: "East Germany",
+  ZR: "Zaire, now CD",
+  TP: "East Timor, now TL",
+  BU: "Burma, now MM",
+  YD: "South Yemen",
+  NT: "Neutral Zone",
+};
+
+describe("Netherlands Antilles (issue #34)", () => {
+  test("AN is not in the dataset", () => {
+    expect(countryCodes.findOne("countryCode", "AN")).toBeUndefined();
+    expect(countryCodes.filter("countryCode", "AN")).toEqual([]);
+  });
+
+  test("the ANT alpha-3 code is not in the dataset", () => {
+    expect(countryCodes.findOne("countryCodeAlpha3", "ANT")).toBeUndefined();
+  });
+
+  test("no entry is named Netherlands Antilles", () => {
+    const named = all.filter((c) =>
+      c.countryNameEn.toLowerCase().includes("netherlands antilles")
+    );
+    expect(named).toEqual([]);
+  });
+
+  test("AN cannot appear as a key in a generated list", () => {
+    const list = countryCodes.customList("countryCode", "{countryNameEn}");
+    expect(list).not.toHaveProperty("AN");
+  });
+
+  test.each([
+    ["CW", "Curaçao", "CUW"],
+    ["SX", "Sint Maarten (Dutch part)", "SXM"],
+    ["BQ", "Bonaire, Sint Eustatius and Saba", "BES"],
+  ])("its successor %s is present and complete", (code, nameEn, alpha3) => {
+    const country = countryCodes.findOne("countryCode", code);
+    expect(country).toBeDefined();
+    expect(country!.countryNameEn).toBe(nameEn);
+    expect(country!.countryCodeAlpha3).toBe(alpha3);
+    // Aruba (AW) left the Antilles in 1986 and was always listed separately.
+    expect(countryCodes.findOne("countryCode", "AW")).toBeDefined();
+  });
+
+  test("the successors are no longer classified as region Unknown", () => {
+    const unknown = all
+      .filter((c) => c.region === "Unknown")
+      .map((c) => c.countryCode);
+    expect(unknown).toEqual([]);
+  });
+
+  test("the successors are classified as Caribbean, not Europe", () => {
+    ["CW", "SX", "BQ"].forEach((code) => {
+      expect(countryCodes.findOne("countryCode", code)!.region).toBe(
+        "South/Latin America"
+      );
+    });
+  });
+});
+
+describe("deleted ISO 3166-1 codes", () => {
+  test.each(Object.entries(DELETED_ALPHA2))(
+    "%s is absent (%s)",
+    (code) => {
+      expect(countryCodes.findOne("countryCode", code)).toBeUndefined();
+    }
+  );
+});


### PR DESCRIPTION
## Summary

The Netherlands Antilles was dissolved on **10 October 2010** and `AN` was deleted from ISO 3166-1. The package still shipped it, so any consumer building a country picker from this data offers users a state that has not existed for 15 years.

The entry was also internally inconsistent — it carried Bonaire's flag (🇧🇶, which belongs to `BQ`) and `region: "Europe"` for a Caribbean territory.

### What changed

- **Removed the `AN` entry.** Its successors were already present and need no migration: `CW` Curaçao, `SX` Sint Maarten, `BQ` Bonaire/Sint Eustatius/Saba. (Aruba `AW` left the Antilles back in 1986 and was always listed separately.)
- **Fixed the successors' region.** `CW`, `SX` and `BQ` were the only three entries in the whole dataset with `region: "Unknown"` — they were added when the Antilles split but never classified. They now use `"South/Latin America"`, the value this dataset already uses for every other Caribbean island (Antigua, Anguilla, Barbados, Dominican Republic, Jamaica, Puerto Rico, Trinidad and Tobago, US Virgin Islands…). After this PR no country has an `Unknown` region.

### Sources

- [ISO 3166-1 alpha-2 § Deleted codes](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Deleted_codes)
- [Dissolution of the Netherlands Antilles](https://en.wikipedia.org/wiki/Dissolution_of_the_Netherlands_Antilles)
- The reference cited in #34: https://2009-2017.state.gov/r/pa/ei/bgn/22528.htm

## Breaking change

`findOne("countryCode", "AN")` now returns `undefined` and the dataset drops from 251 to 250 entries. Consumers displaying *historical* records that still contain `AN` will need their own mapping to `CW`/`SX`/`BQ`. Worth a major version.

If you'd prefer to keep withdrawn codes available behind an opt-in flag rather than delete them outright, say so and I'll rework this into a `withdrawn: true` marker that's filtered out of the default export instead — happy either way, deletion just seemed closest to what the issue asks.

## Test plan

New suite `tests/withdrawnCountries.test.ts` (18 tests):

- [x] `AN` is unreachable through every public lookup — `findOne`, `filter`, and as a key in `customList` output.
- [x] The `ANT` alpha-3 code is gone too, and no entry is named "Netherlands Antilles".
- [x] Each successor (`CW`, `SX`, `BQ`) is asserted present with its exact name and alpha-3 code, so removing `AN` can't be done by accidentally deleting a successor instead.
- [x] **Dataset-wide invariant**: no country has `region: "Unknown"`. This guards the whole file, not just these three.
- [x] **Guards against regression**: a table of formally deleted ISO 3166-1 alpha-2 codes (`AN`, `CS`, `YU`, `DD`, `ZR`, `TP`, `BU`, `YD`, `NT`) is asserted absent, so no withdrawn code can be re-introduced unnoticed.
- [x] **RED-verified**: against `master` 7 of these tests fail; they pass only with the change.
- [x] `npm run build` clean, `npm test` 26/26 passing.

## Note on merge order

#60 also touches the `BQ`, `CW` and `SX` entries (different lines — `countryCallingCode`/`areaCodes` rather than `region`), and adds `areaCodes: []` to the `AN` entry this PR deletes. If #60 lands first, rebasing this branch is a one-hunk "accept the deletion" on `AN`. Merging in either order is fine, I'll rebase whichever lands second.

Fixes #34
