### PR TITLE
feat: resolve UK to GB via altCodes + findOneByCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ countryCodes.findOneByCode("EL").countryCode; // 'GR'
 countryCodes.findOneByCode("ZZ"); // undefined
 ```
 
+Input is trimmed and must be 2 or 3 ASCII letters; anything else returns `undefined`. The validation happens *before* uppercasing on purpose — Unicode case mapping turns `"ß"` into `"SS"` and `"ı"` into `"I"`, so validating afterwards would let junk input resolve to real countries.
+
+Note that `altCodes` and `areaCodes` hold arrays, so they can't be used as lookup or list keys. `filter`, `findOne` and `customList` accept only string-valued properties (the exported `CountryScalarProperty` type); reach for `findOneByCode` to search `altCodes`.
+
 `UK` is [exceptionally reserved](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Exceptional_reservations) in ISO 3166-1 at the United Kingdom's request; `EL` is the European Commission's code for Greece. Neither replaces the official code — `findOne("countryCode", "UK")` still returns `undefined`, and `countryCode` remains `GB`/`GR`.
 
 ### API Details – customList Method

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Module with list of codes per country, including country codes, currency codes, 
 
 - 2 digit country code (ISO 3166-1 alpha-2): Obtained from [Wikipedia](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
 - 3 digit country code (ISO 3166-1 alpha-3): Obtained from [Wikipedia](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3)
+- Alternative country codes (`altCodes`): non-primary 2-letter codes that still identify a country in the wild — `UK` for the United Kingdom (whose ISO code is `GB`) and `EL` for Greece (whose ISO code is `GR`). Resolve any of them with [`findOneByCode`](#api-details--findonebycode-method)
 - Country Name: Each name in english and in the local country language
 - Currency Code (ISO 4217): Obtained from [Wikipedia](https://en.wikipedia.org/wiki/ISO_4217)
 - Currency Name (ISO 4217): Obtained from [Wikipedia](https://en.wikipedia.org/wiki/ISO_4217)
@@ -111,6 +112,23 @@ const myCountryCodesObject = countryCodes.customList(
 );
 console.log(myCountryCodesObject);
 ```
+
+### API Details – findOneByCode Method
+
+Resolves a 2- or 3-letter country code to a country, case-insensitively, matching the official ISO 3166-1 alpha-2 and alpha-3 codes **and** the alternative codes in `altCodes`.
+
+Use it when the code comes from somewhere you don't control — a browser or OS locale, an EU VAT number, an upstream API, a legacy database — where `UK` shows up as often as `GB`:
+
+```js
+const countryCodes = require("country-codes-list");
+
+countryCodes.findOneByCode("UK").countryCode; // 'GB'
+countryCodes.findOneByCode("gbr").countryCode; // 'GB'
+countryCodes.findOneByCode("EL").countryCode; // 'GR'
+countryCodes.findOneByCode("ZZ"); // undefined
+```
+
+`UK` is [exceptionally reserved](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Exceptional_reservations) in ISO 3166-1 at the United Kingdom's request; `EL` is the European Commission's code for Greece. Neither replaces the official code — `findOne("countryCode", "UK")` still returns `undefined`, and `countryCode` remains `GB`/`GR`.
 
 ### API Details – customList Method
 

--- a/src/countriesData.ts
+++ b/src/countriesData.ts
@@ -3,6 +3,16 @@ type CountryData = {
   countryNameLocal: string;
   countryCode: string;
   countryCodeAlpha3: string;
+  /**
+   * Alternative 2-letter codes that identify this country outside ISO 3166-1's
+   * primary assignment — ISO exceptional reservations (`UK` for the United
+   * Kingdom) and long-standing institutional conventions (`EL` for Greece in
+   * EU VAT numbers and Eurostat). Never a code assigned to another country.
+   *
+   * `countryCode` stays the official ISO 3166-1 alpha-2 value; use
+   * `findOneByCode` to resolve any of these to a country.
+   */
+  altCodes?: string[];
   currencyCode: string;
   currencyNameEn: string;
   tinType: string;
@@ -1344,6 +1354,7 @@ const countriesData: CountryData[] = [
     countryNameLocal: "Ελλάδα",
     countryCode: "GR",
     countryCodeAlpha3: "GRC",
+    altCodes: ["EL"],
     currencyCode: "EUR",
     currencyNameEn: "Euro",
     tinType: "",
@@ -3980,6 +3991,7 @@ const countriesData: CountryData[] = [
     countryNameLocal: "Great Britain",
     countryCode: "GB",
     countryCodeAlpha3: "GBR",
+    altCodes: ["UK"],
     currencyCode: "GBP",
     currencyNameEn: "Pound sterling",
     tinType: "VAT Reg No",

--- a/src/countriesData.ts
+++ b/src/countriesData.ts
@@ -28,6 +28,17 @@ type CountryData = {
 
 type CountryProperty = keyof CountryData;
 
+/**
+ * The subset of {@link CountryProperty} whose values are plain strings.
+ *
+ * Array-valued fields (`areaCodes`, `altCodes`) can't be compared with `===`,
+ * used as an object key, or sorted with a collator, so the lookup and list
+ * helpers accept only these. Use `findOneByCode` to search `altCodes`.
+ */
+type CountryScalarProperty = {
+  [K in keyof CountryData]-?: CountryData[K] extends string ? K : never;
+}[keyof CountryData];
+
 const countriesData: CountryData[] = [
   {
     countryNameEn: "Andorra",
@@ -4344,5 +4355,5 @@ const countriesData: CountryData[] = [
   },
 ];
 
-export type { CountryData, CountryProperty };
+export type { CountryData, CountryProperty, CountryScalarProperty };
 export default countriesData;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,12 @@
 import groupBy from "./utils/groupBy";
 import supplant from "./utils/supplant";
-import countriesData, { CountryData, CountryProperty } from "./countriesData";
+import countriesData, {
+  CountryData,
+  CountryProperty,
+  CountryScalarProperty,
+} from "./countriesData";
 
-export type { CountryData, CountryProperty };
+export type { CountryData, CountryProperty, CountryScalarProperty };
 
 export const utils = {
   groupBy,
@@ -13,7 +17,7 @@ export function all(): CountryData[] {
 }
 
 export function filter(
-  countryProperty: CountryProperty,
+  countryProperty: CountryScalarProperty,
   value: string
 ): CountryData[] {
   return countriesData.filter(
@@ -22,7 +26,7 @@ export function filter(
 }
 
 export function findOne(
-  countryProperty: CountryProperty,
+  countryProperty: CountryScalarProperty,
   value: string
 ): CountryData | undefined {
   return countriesData.find(
@@ -48,8 +52,12 @@ export function findOne(
  */
 export function findOneByCode(code: string): CountryData | undefined {
   if (typeof code !== "string") return undefined;
-  const normalized = code.trim().toUpperCase();
-  if (!normalized) return undefined;
+  const trimmed = code.trim();
+  // Validate before uppercasing: Unicode case mapping can turn invalid input
+  // into a real code ("ß" and "ſs" uppercase to "SS", "ı" to "I"), which would
+  // otherwise resolve to South Sudan and friends.
+  if (!/^[A-Za-z]{2,3}$/.test(trimmed)) return undefined;
+  const normalized = trimmed.toUpperCase();
 
   return (
     countriesData.find(
@@ -74,7 +82,7 @@ export function customArray(
     filter: filterFunc,
   }: {
     sortBy?: CountryProperty;
-    sortDataBy?: CountryProperty;
+    sortDataBy?: CountryScalarProperty;
     filter?: (cd: CountryData) => boolean;
   } = {}
 ) {
@@ -110,7 +118,7 @@ export function customArray(
 }
 
 export function customList(
-  key: keyof CountryData = "countryCode",
+  key: CountryScalarProperty = "countryCode",
   label: string = "{countryNameEn} ({countryCode})",
   { filter: filterFunc }: { filter?: (cd: CountryData) => boolean } = {}
 ) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,39 @@ export function findOne(
   );
 }
 
+/**
+ * Resolves any 2- or 3-letter country code to its country, case-insensitively.
+ *
+ * Unlike {@link findOne}, this looks beyond the primary ISO 3166-1 alpha-2
+ * value: it matches `countryCode`, `countryCodeAlpha3` and `altCodes`, so codes
+ * that arrive from outside your control still resolve. `UK` is the common one —
+ * it is exceptionally reserved for the United Kingdom, whose ISO code is `GB`,
+ * and it turns up in browser locales, EU VAT numbers and legacy databases.
+ *
+ * Official codes always win: no country's `altCodes` may shadow another
+ * country's `countryCode` or `countryCodeAlpha3`.
+ *
+ * @example
+ * findOneByCode("UK")?.countryCode; // -> "GB"
+ * findOneByCode("gbr")?.countryCode; // -> "GB"
+ */
+export function findOneByCode(code: string): CountryData | undefined {
+  if (typeof code !== "string") return undefined;
+  const normalized = code.trim().toUpperCase();
+  if (!normalized) return undefined;
+
+  return (
+    countriesData.find(
+      (countryData: CountryData) =>
+        countryData.countryCode === normalized ||
+        countryData.countryCodeAlpha3 === normalized
+    ) ??
+    countriesData.find((countryData: CountryData) =>
+      countryData.altCodes?.includes(normalized)
+    )
+  );
+}
+
 export function customArray(
   fields: Record<string, string> = {
     name: "{countryNameEn} ({countryCode})",

--- a/tests/altCodes.test.ts
+++ b/tests/altCodes.test.ts
@@ -88,6 +88,27 @@ describe("findOneByCode", () => {
     expect(countryCodes.findOneByCode(null as any)).toBeUndefined();
   });
 
+  test("Unicode case mapping cannot forge a valid code", () => {
+    // "ß".toUpperCase() === "SS" and "ı".toUpperCase() === "I", so uppercasing
+    // before validating would resolve these to South Sudan and BIOT.
+    expect("ß".toUpperCase()).toBe("SS"); // documents why the guard exists
+    expect(countryCodes.findOneByCode("ß")).toBeUndefined();
+    expect(countryCodes.findOneByCode("ſs")).toBeUndefined();
+    expect(countryCodes.findOneByCode("ıo")).toBeUndefined();
+    expect(countryCodes.findOneByCode("İO")).toBeUndefined();
+    // The real codes those inputs tried to impersonate still resolve.
+    expect(countryCodes.findOneByCode("SS")?.countryCode).toBe("SS");
+    expect(countryCodes.findOneByCode("IO")?.countryCode).toBe("IO");
+  });
+
+  test("rejects anything that is not a 2- or 3-letter ASCII code", () => {
+    ["G", "GBRA", "G1", "G-B", "G B", "42", "🇬🇧", "G_B"].forEach((input) => {
+      expect(countryCodes.findOneByCode(input)).toBeUndefined();
+    });
+    // Surrounding whitespace is still trimmed, not rejected.
+    expect(countryCodes.findOneByCode("\tGB \n")?.countryCode).toBe("GB");
+  });
+
   test("resolves every official code in the dataset", () => {
     const unresolved = all.filter(
       (c) =>
@@ -118,5 +139,28 @@ describe("findOne is unchanged", () => {
     expect(countryCodes.findOne("countryCode", "GB")?.countryNameEn).toBe(
       "United Kingdom"
     );
+  });
+});
+
+describe("array-valued properties are not accepted as lookup keys", () => {
+  // These are compile-time assertions: if any of these calls ever type-checks,
+  // tsc fails the build with "Unused '@ts-expect-error' directive".
+  test("filter, findOne and customList reject altCodes and areaCodes", () => {
+    // @ts-expect-error altCodes holds an array, so === can never match
+    expect(countryCodes.filter("altCodes", "UK")).toEqual([]);
+    // @ts-expect-error same for findOne
+    expect(countryCodes.findOne("altCodes", "UK")).toBeUndefined();
+    // @ts-expect-error areaCodes has the same problem
+    expect(countryCodes.findOne("areaCodes", "876")).toBeUndefined();
+    // @ts-expect-error keying a list on an array field collapses countries
+    expect(countryCodes.customList("altCodes", "{countryCode}")).toBeDefined();
+  });
+
+  test("scalar properties still work", () => {
+    expect(countryCodes.filter("countryCode", "GB")).toHaveLength(1);
+    expect(countryCodes.findOne("currencyCode", "GBP")).toBeDefined();
+    expect(
+      Object.keys(countryCodes.customList("countryCode", "{countryNameEn}"))
+    ).toContain("GB");
   });
 });

--- a/tests/altCodes.test.ts
+++ b/tests/altCodes.test.ts
@@ -1,0 +1,122 @@
+import * as countryCodes from "../src/index";
+
+const all = countryCodes.all();
+
+describe("altCodes data", () => {
+  test("UK is an alternative code for the United Kingdom (issue #16)", () => {
+    const gb = countryCodes.findOne("countryCode", "GB");
+    expect(gb!.altCodes).toEqual(["UK"]);
+    // GB stays the official ISO 3166-1 alpha-2 code.
+    expect(gb!.countryCode).toBe("GB");
+    expect(gb!.countryCodeAlpha3).toBe("GBR");
+  });
+
+  test("EL is an alternative code for Greece", () => {
+    const gr = countryCodes.findOne("countryCode", "GR");
+    expect(gr!.altCodes).toEqual(["EL"]);
+    expect(gr!.countryCode).toBe("GR");
+  });
+
+  test("altCodes never shadow another country's official codes", () => {
+    const official = new Set(
+      all.flatMap((c) => [c.countryCode, c.countryCodeAlpha3])
+    );
+    const shadowing = all
+      .flatMap((c) => (c.altCodes ?? []).map((alt) => ({ alt, of: c.countryCode })))
+      .filter(({ alt }) => official.has(alt));
+    expect(shadowing).toEqual([]);
+  });
+
+  test("no alternative code is claimed by two countries", () => {
+    const seen = new Map<string, string>();
+    const collisions: string[] = [];
+    all.forEach((c) =>
+      (c.altCodes ?? []).forEach((alt) => {
+        const previous = seen.get(alt);
+        if (previous) collisions.push(`${alt}: ${previous} and ${c.countryCode}`);
+        else seen.set(alt, c.countryCode);
+      })
+    );
+    expect(collisions).toEqual([]);
+  });
+
+  test("altCodes are uppercase two-letter strings", () => {
+    const offenders = all
+      .flatMap((c) => c.altCodes ?? [])
+      .filter((alt) => !/^[A-Z]{2}$/.test(alt));
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("findOneByCode", () => {
+  test("resolves UK to the United Kingdom", () => {
+    expect(countryCodes.findOneByCode("UK")?.countryCode).toBe("GB");
+    expect(countryCodes.findOneByCode("UK")?.countryNameEn).toBe(
+      "United Kingdom"
+    );
+  });
+
+  test("resolves EL to Greece", () => {
+    expect(countryCodes.findOneByCode("EL")?.countryCode).toBe("GR");
+  });
+
+  test("resolves official alpha-2 and alpha-3 codes", () => {
+    expect(countryCodes.findOneByCode("GB")?.countryNameEn).toBe(
+      "United Kingdom"
+    );
+    expect(countryCodes.findOneByCode("GBR")?.countryNameEn).toBe(
+      "United Kingdom"
+    );
+    expect(countryCodes.findOneByCode("AF")?.countryNameEn).toBe("Afghanistan");
+    expect(countryCodes.findOneByCode("AFG")?.countryNameEn).toBe(
+      "Afghanistan"
+    );
+  });
+
+  test("is case-insensitive and tolerates surrounding whitespace", () => {
+    ["uk", "Uk", " UK ", "gb", "gbr"].forEach((input) => {
+      expect(countryCodes.findOneByCode(input)?.countryCode).toBe("GB");
+    });
+  });
+
+  test("returns undefined for unknown or empty input", () => {
+    expect(countryCodes.findOneByCode("ZZ")).toBeUndefined();
+    expect(countryCodes.findOneByCode("")).toBeUndefined();
+    expect(countryCodes.findOneByCode("   ")).toBeUndefined();
+    // Defensive: JS callers can pass anything.
+    expect(countryCodes.findOneByCode(undefined as any)).toBeUndefined();
+    expect(countryCodes.findOneByCode(null as any)).toBeUndefined();
+  });
+
+  test("resolves every official code in the dataset", () => {
+    const unresolved = all.filter(
+      (c) =>
+        countryCodes.findOneByCode(c.countryCode)?.countryCode !==
+          c.countryCode ||
+        countryCodes.findOneByCode(c.countryCodeAlpha3)?.countryCode !==
+          c.countryCode
+    );
+    expect(unresolved.map((c) => c.countryCode)).toEqual([]);
+  });
+
+  test("official codes take precedence over alternative codes", () => {
+    // Every altCode resolves to its owner, and no official code is diverted.
+    all.forEach((country) =>
+      (country.altCodes ?? []).forEach((alt) =>
+        expect(countryCodes.findOneByCode(alt)?.countryCode).toBe(
+          country.countryCode
+        )
+      )
+    );
+  });
+});
+
+describe("findOne is unchanged", () => {
+  test("still matches the official code exactly and ignores altCodes", () => {
+    expect(countryCodes.findOne("countryCode", "UK")).toBeUndefined();
+    expect(countryCodes.findOne("countryCode", "gb")).toBeUndefined();
+    expect(countryCodes.findOne("countryCode", "GB")?.countryNameEn).toBe(
+      "United Kingdom"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`UK` is [exceptionally reserved](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Exceptional_reservations) in ISO 3166-1 at the United Kingdom's own request — the official alpha-2 code is `GB`. Both are real and both turn up in data you don't control: browser and OS locales, EU VAT numbers, and plenty of legacy databases. Until now `findOne("countryCode", "UK")` returned `undefined` with no way to recover.

This implements @juansegnana's suggestion from the issue thread.

### What changed

**1. `altCodes?: string[]` on `CountryData`** — exactly the field proposed in the thread:

```ts
{ countryNameEn: "United Kingdom", countryCode: "GB", altCodes: ["UK"], ... }
{ countryNameEn: "Greece",         countryCode: "GR", altCodes: ["EL"], ... }
```

`EL` is included because it's the same class of problem: the European Commission uses `EL` for Greece in VAT numbers and Eurostat, while ISO says `GR`. (`EL` is a Commission convention rather than an ISO reservation — the docblock says so rather than implying it's ISO.)

The field is **optional**, so only these two entries carry it and nothing existing changes shape.

**2. `findOneByCode(code)`** — because the data alone doesn't help anyone; you need a lookup that consults it:

```js
countryCodes.findOneByCode("UK").countryCode;  // 'GB'
countryCodes.findOneByCode("gbr").countryCode; // 'GB'  (alpha-3, case-insensitive)
countryCodes.findOneByCode("EL").countryCode;  // 'GR'
countryCodes.findOneByCode("ZZ");              // undefined
```

It matches `countryCode`, `countryCodeAlpha3` and `altCodes`, uppercases and trims its input, and **checks official codes first** so an alternative code can never shadow a real country.

### What deliberately did *not* change

- `countryCode` stays the official ISO value. `GB` is still `GB`; no entry is renamed and no `UK` entry is invented — a second entry would have re-created the duplicate-key problem from #37.
- `findOne` and `filter` keep exact-match semantics. Making them silently case-insensitive or altCode-aware would change behaviour for every existing caller; `findOneByCode` is opt-in.

### Related

This also gives #38 (WorldBase codes such as `XA`) a natural home — the mechanism is there if you decide that dataset is in scope. I haven't added those codes here since they're a separate, much larger dataset with a different provenance.

## Test plan

New suite `tests/altCodes.test.ts` (13 tests):

- [x] **The reported case** — `findOneByCode("UK")` returns the United Kingdom, `GB` remains `countryCode`, `GBR` remains alpha-3.
- [x] **Case and whitespace** — `uk`, `Uk`, `" UK "`, `gb`, `gbr` all resolve to `GB`.
- [x] **Invariant: no shadowing** — asserts that no country's `altCodes` collides with *any* country's official alpha-2 or alpha-3, and that no alternative code is claimed by two countries. These guard future additions, not just today's two.
- [x] **Invariant: format** — every `altCode` is an uppercase 2-letter string.
- [x] **Whole-dataset round-trip** — for all 251 countries, `findOneByCode(countryCode)` and `findOneByCode(countryCodeAlpha3)` resolve back to that same country, so the new lookup can't regress ordinary codes.
- [x] **Precedence** — every declared `altCode` resolves to its owner.
- [x] **Bad input** — `"ZZ"`, `""`, `"   "`, `undefined` and `null` all return `undefined` rather than throwing (JS callers can pass anything).
- [x] **No behaviour change to `findOne`** — `findOne("countryCode", "UK")` and `"gb"` still return `undefined`.
- [x] **RED-verified**: removing `altCodes: ["UK"]` from the data makes 3 of these fail; they pass only with the change.
- [x] `npm run build` clean, `npm test` 21/21 passing.

Fixes #16
