### PR TITLE
Release v3.0.0: bump version and add v2 to v3 migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 Module with list of codes per country, including country codes, currency codes, and more.
 
 > [!WARNING]
-> Release v2.0.0 introduces breaking changes with full TypeScript support and automated testing/publishing.
+> Release v3.0.0 introduces breaking changes: `countryCallingCode` no longer folds in national area codes, `areaCodes` is now a required `string[]`, and several functions narrow their key parameter to string-valued properties. See the [v2 → v3 migration guide](#migration-guide-v2x-to-v30).
+>
+> Release v2.0.0 introduced breaking changes with full TypeScript support and automated testing/publishing.
 
 ## Features
 
@@ -83,6 +85,36 @@ npm test
    ```typescript
    // This now requires valid country property keys
    countryCodes.filter("invalidKey", "value"); // TypeScript error
+   ```
+
+## Migration Guide (v2.x to v3.0)
+
+### Breaking Changes
+
+1. **`countryCallingCode` is now the ITU-T E.164 country code only** — national area codes are no longer folded in. Several countries changed value, most notably the [NANP](https://en.wikipedia.org/wiki/North_American_Numbering_Plan) members that used to carry their area code:
+
+   ```js
+   // Old (v2.x)
+   countryCodes.findOne("countryCode", "JM").countryCallingCode; // '876'
+
+   // New (v3.0)
+   countryCodes.findOne("countryCode", "JM").countryCallingCode; // '1'
+   countryCodes.findOne("countryCode", "JM").areaCodes; // ['876', '658']
+   ```
+
+   If you relied on the old value to dial a full number, concatenate the calling code with an area code: `` `+${cc}${areaCodes[0]}` ``.
+
+2. **`areaCodes` is now a required `string[]`** (previously an optional `any[]`). It is **partially populated** — an empty array means "not recorded", not "no area codes". Every NANP member is populated; other shared calling codes (`44`, `358`, `61`) are not yet.
+
+3. **Key parameters narrowed to `CountryScalarProperty`.** `filter`, `findOne`, `customList`, `customGroupedList` and `customArray`'s `sortDataBy` no longer accept array-valued properties (`altCodes`, `areaCodes`). This was already broken at runtime; it is now a compile-time error:
+
+   ```typescript
+   // Old (v2.x): type-checked but returned garbage at runtime
+   countryCodes.customList("altCodes", "{countryCode}");
+
+   // New (v3.0): TypeScript error
+   // To look up by an alternative code, use findOneByCode instead:
+   countryCodes.findOneByCode("UK").countryCode; // 'GB'
    ```
 
 ## Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "country-codes-list",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "country-codes-list",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "country-codes-list",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "List of codes per country (languages, calling codes, currency codes, etc) with full TypeScript support.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Prepares the v3.0.0 release now that #60, #61, #62 and #63 are merged.

## What's in this PR
- Bump version to `3.0.0` (package.json + package-lock.json root entries).
- Update the top warning banner to point at the new migration guide.
- Add a **Migration Guide (v2.x to v3.0)** section to the README.

## Why a major
The merged work carries breaking changes:
1. `countryCallingCode` is now the ITU-T E.164 country code only. Area codes are no longer folded in, so several countries changed value (e.g. Jamaica `876` -> `1`, with `areaCodes: ['876', '658']`).
2. `areaCodes` is now a required `string[]` (was an optional `any[]`).
3. `filter`, `findOne`, `customList`, `customGroupedList` and `customArray`'s `sortDataBy` narrow their key parameter to `CountryScalarProperty`, so array-valued properties (`altCodes`, `areaCodes`) no longer type-check.

## Release steps after merge
Tagging `v3.0.0` triggers `publish.yml`, which builds, tests and publishes to npm via Trusted Publishing, then creates the GitHub Release:

```
git tag v3.0.0 origin/master
git push origin v3.0.0
```

## Verification
- `npm run build` clean, `npm test` green (91 tests).
- Migration examples checked against the built data: JM resolves to calling code `1` with `areaCodes ['876', '658']`, and `findOneByCode('UK').countryCode` is `GB`.