### PR TITLE
fix: Sierra Leone redenominated the leone (SLL → SLE)

### DIFF
--- a/src/countriesData.ts
+++ b/src/countriesData.ts
@@ -3098,7 +3098,7 @@ const countriesData: CountryData[] = [
     countryNameLocal: "Sierra Leone",
     countryCode: "SL",
     countryCodeAlpha3: "SLE",
-    currencyCode: "SLL",
+    currencyCode: "SLE",
     currencyNameEn: "Sierra Leonean leone",
     tinType: "",
     tinName: "",

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -46,6 +46,10 @@ describe("country-codes-list", () => {
     expect(list["AD"]).toBeDefined();
   });
 
+  test("Sierra Leone uses the redenominated leone (SLE)", () => {
+    expect(countryCodes.findOne("countryCode", "SL")?.currencyCode).toBe("SLE");
+  });
+
   test("currency codes are valid ISO 4217 for Bolivia and Belarus", () => {
     expect(countryCodes.findOne("countryCode", "BO")?.currencyCode).toBe("BOB");
     expect(countryCodes.findOne("countryCode", "BY")?.currencyCode).toBe("BYN");


### PR DESCRIPTION
Sierra Leone redenominated the leone on **2022-07-01** (1 SLE = 1000 SLL). The old code `SLL` was removed from ISO 4217 (amendment 174, effective end of 2023) — `SLE` is the only valid code today. `currencyNameEn` stays "Sierra Leonean leone".

- `SL`: `SLL` → `SLE`

Adds a regression test via the public API. Verified with `npm run build && npm test` (all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)