### PR TITLE
Release v3.1.0: currency code updates (EUR, SLE, CUP, XCG, ZWG)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "country-codes-list",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "country-codes-list",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "country-codes-list",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "List of codes per country (languages, calling codes, currency codes, etc) with full TypeScript support.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps version to 3.1.0 for the release containing PRs #65-#69 (dead currency codes updated: HRK/BGN -> EUR, SLL -> SLE, CUC -> CUP, ANG -> XCG, ZWL -> ZWG).

Minor (not patch) because currency code values change observably for consumers keying logic off the old codes; no API or schema changes, so not a major.

Note: tag v3.1.0 already points to this commit and the npm publish workflow runs from the tag.