### PR TITLE
fix: stop the public API from mutating the shared dataset

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,17 @@ export const utils = {
   groupBy,
 };
 
+/**
+ * Every country in the dataset, in dataset order.
+ *
+ * Returns a fresh array each call, so reordering or resizing it is safe — the
+ * dataset is module state shared by every export, and handing out a live
+ * reference let one consumer's `sort()` or `push()` change what every later
+ * call returned. The country objects themselves are still shared: treat them
+ * as read-only.
+ */
 export function all(): CountryData[] {
-  return countriesData;
+  return [...countriesData];
 }
 
 export function filter(
@@ -94,7 +103,10 @@ export function customArray(
 
   if (sortDataBy) {
     const collator = new Intl.Collator([], { sensitivity: "accent" });
-    data.sort((a: CountryData, b: CountryData) =>
+    // Copy before sorting: without a `filter`, `data` still aliases
+    // `countriesData`, and an in-place sort would permanently reorder the
+    // dataset for `all`, `customList` and `customGroupedList` too.
+    data = [...data].sort((a: CountryData, b: CountryData) =>
       collator.compare(a[sortDataBy] as string, b[sortDataBy] as string)
     );
   }

--- a/tests/immutability.test.ts
+++ b/tests/immutability.test.ts
@@ -1,0 +1,78 @@
+import * as countryCodes from "../src/index";
+
+/**
+ * The dataset is module state shared by every export. No public function may
+ * reorder or resize it, and no value handed to a consumer may be a live
+ * reference to it — otherwise one call silently changes what every later call
+ * returns, for the whole process.
+ */
+describe("the shared dataset survives the public API", () => {
+  test("customArray with sortDataBy leaves the dataset order untouched", () => {
+    const before = countryCodes.all().map((country) => country.countryCode);
+
+    countryCodes.customArray(
+      { name: "{countryNameEn}", value: "{countryCode}" },
+      { sortDataBy: "countryNameLocal" }
+    );
+
+    expect(countryCodes.all().map((country) => country.countryCode)).toEqual(
+      before
+    );
+  });
+
+  test("customArray with sortDataBy keeps customGroupedList's documented dataset order", () => {
+    const before = countryCodes.customGroupedList(
+      "countryCallingCode",
+      "{countryCode}"
+    )["1"];
+
+    countryCodes.customArray(
+      { name: "{countryNameEn}", value: "{countryCode}" },
+      { sortDataBy: "countryNameEn" }
+    );
+
+    expect(
+      countryCodes.customGroupedList("countryCallingCode", "{countryCode}")["1"]
+    ).toEqual(before);
+  });
+
+  test("customArray still sorts its own output when sortDataBy is given", () => {
+    const result = countryCodes.customArray(
+      { name: "{countryNameEn}", value: "{countryCode}" },
+      { sortDataBy: "countryNameEn" }
+    );
+
+    const names = result.map((entry) => entry.name);
+    const collator = new Intl.Collator([], { sensitivity: "accent" });
+    expect(names).toEqual([...names].sort(collator.compare));
+  });
+
+  test("sortDataBy composes with filter without touching the dataset", () => {
+    const before = countryCodes.all().map((country) => country.countryCode);
+
+    const result = countryCodes.customArray(
+      { value: "{countryCode}" },
+      {
+        filter: (country) => country.countryCallingCode === "1",
+        sortDataBy: "countryNameEn",
+      }
+    );
+
+    expect(result.length).toBeGreaterThan(1);
+    expect(countryCodes.all().map((country) => country.countryCode)).toEqual(
+      before
+    );
+  });
+
+  test("all() hands out a copy, so a consumer cannot corrupt the dataset", () => {
+    const pristine = countryCodes.all().map((country) => country.countryCode);
+
+    const handed = countryCodes.all();
+    handed.push(handed[0]);
+    handed.reverse();
+
+    expect(countryCodes.all().map((country) => country.countryCode)).toEqual(
+      pristine
+    );
+  });
+});


### PR DESCRIPTION
## The bug

`customArray(fields, { sortDataBy })` sorts the module-level `countriesData` array **in place**.

```js
const cc = require("country-codes-list");

cc.all().slice(0, 5).map(c => c.countryCode);
// -> [ 'AD', 'AF', 'AG', 'AI', 'AL' ]

cc.customArray({ value: "{countryCode}" }, { sortDataBy: "countryNameLocal" });

cc.all().slice(0, 5).map(c => c.countryCode);
// -> [ 'AF', 'AX', 'AL', 'DZ', 'AS' ]   <- permanently reordered
```

Without a `filter`, `data` is an alias of the shared array (`src/index.ts:90`), so `.sort()` at line 97 mutates module state. Every later `all()`, `filter()`, `findOne()`, `customList()` and `customGroupedList()` call in the process sees the new order — including the dataset order `customGroupedList` documents as a guarantee.

`all()` had the mirror problem (`src/index.ts:15-17`): it returned the live internal array, so a consumer's `push()` / `sort()` / `splice()` corrupted the package for every other consumer in the process.

## The fix

- `customArray` copies before sorting, and only when `sortDataBy` is given — the common path allocates nothing extra.
- `all()` returns a fresh array each call.

The country objects themselves are still shared by reference and are now documented as read-only; freezing them would be a breaking change and belongs in a major.

## Verification

`tests/immutability.test.ts` (new): **3 of its 5 cases fail on `master`** and all 5 pass here. The two that pass without the fix are deliberate — `filter` already returns a new array, so the bug only appears on the unfiltered path, and one case pins that `sortDataBy` still sorts its own output.

Full suite: 101 passed (96 before), `tsc` clean.