### PR TITLE
fix: stop the public API from mutating the shared dataset (+ review fixes)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,17 @@ export const utils = {
   groupBy,
 };
 
+/**
+ * Every country in the dataset, in dataset order.
+ *
+ * Returns a fresh array each call, so reordering or resizing it is safe — the
+ * dataset is module state shared by every export, and handing out a live
+ * reference let one consumer's `sort()` or `push()` change what every later
+ * call returned. The country objects themselves are still shared: treat them
+ * as read-only.
+ */
 export function all(): CountryData[] {
-  return countriesData;
+  return [...countriesData];
 }
 
 export function filter(
@@ -94,7 +103,10 @@ export function customArray(
 
   if (sortDataBy) {
     const collator = new Intl.Collator([], { sensitivity: "accent" });
-    data.sort((a: CountryData, b: CountryData) =>
+    // Copy before sorting: without a `filter`, `data` still aliases
+    // `countriesData`, and an in-place sort would permanently reorder the
+    // dataset for `all`, `customList` and `customGroupedList` too.
+    data = [...data].sort((a: CountryData, b: CountryData) =>
       collator.compare(a[sortDataBy] as string, b[sortDataBy] as string)
     );
   }

--- a/tests/immutability.test.ts
+++ b/tests/immutability.test.ts
@@ -1,0 +1,78 @@
+import * as countryCodes from "../src/index";
+
+/**
+ * The dataset is module state shared by every export. No public function may
+ * reorder or resize it, and no value handed to a consumer may be a live
+ * reference to it — otherwise one call silently changes what every later call
+ * returns, for the whole process.
+ */
+describe("the shared dataset survives the public API", () => {
+  test("customArray with sortDataBy leaves the dataset order untouched", () => {
+    const before = countryCodes.all().map((country) => country.countryCode);
+
+    countryCodes.customArray(
+      { name: "{countryNameEn}", value: "{countryCode}" },
+      { sortDataBy: "countryNameLocal" }
+    );
+
+    expect(countryCodes.all().map((country) => country.countryCode)).toEqual(
+      before
+    );
+  });
+
+  test("customArray with sortDataBy keeps customGroupedList's documented dataset order", () => {
+    const before = countryCodes.customGroupedList(
+      "countryCallingCode",
+      "{countryCode}"
+    )["1"];
+
+    countryCodes.customArray(
+      { name: "{countryNameEn}", value: "{countryCode}" },
+      { sortDataBy: "countryNameEn" }
+    );
+
+    expect(
+      countryCodes.customGroupedList("countryCallingCode", "{countryCode}")["1"]
+    ).toEqual(before);
+  });
+
+  test("customArray still sorts its own output when sortDataBy is given", () => {
+    const result = countryCodes.customArray(
+      { name: "{countryNameEn}", value: "{countryCode}" },
+      { sortDataBy: "countryNameEn" }
+    );
+
+    const names = result.map((entry) => entry.name);
+    const collator = new Intl.Collator([], { sensitivity: "accent" });
+    expect(names).toEqual([...names].sort(collator.compare));
+  });
+
+  test("sortDataBy composes with filter without touching the dataset", () => {
+    const before = countryCodes.all().map((country) => country.countryCode);
+
+    const result = countryCodes.customArray(
+      { value: "{countryCode}" },
+      {
+        filter: (country) => country.countryCallingCode === "1",
+        sortDataBy: "countryNameEn",
+      }
+    );
+
+    expect(result.length).toBeGreaterThan(1);
+    expect(countryCodes.all().map((country) => country.countryCode)).toEqual(
+      before
+    );
+  });
+
+  test("all() hands out a copy, so a consumer cannot corrupt the dataset", () => {
+    const pristine = countryCodes.all().map((country) => country.countryCode);
+
+    const handed = countryCodes.all();
+    handed.push(handed[0]);
+    handed.reverse();
+
+    expect(countryCodes.all().map((country) => country.countryCode)).toEqual(
+      pristine
+    );
+  });
+});


### PR DESCRIPTION
Extends #71 with the two non-blocking suggestions @juansegnana left on that PR's review, on top of the same underlying fix. #71 is left untouched.

## What #71 already fixes
`customArray({ sortDataBy })` and `all()` used to hand out (or sort in place) a live reference to the shared internal dataset, so one caller's `sort()`/`push()` could corrupt what every later call to `all()`, `filter()`, `findOne()`, `customList()`, etc. saw.

## What this PR adds on top

1. **JSDoc for read-only / live references** — `filter()` and `findOne()` had no documentation at all; `findOneByCode()`'s didn't mention the sharing behavior either. Added a note to each, consistent with the one already on `all()`, clarifying that the returned country object(s) are live references into the shared dataset and should be treated as read-only.

2. **README breaking-change note** — the fix changes `all()` so it now returns a *new* array on every call, so `all() === all()` is no longer `true` (it was before the fix, which was itself the bug). Added an entry to the existing `> [!WARNING]` breaking-changes block in the README, in the same format as the existing v3.0.0/v2.0.0 entries, explaining the change and that the previous reference-equality behavior was the bug being fixed.

## Testing

- `npm test` — all 101 tests pass (6 suites, including `tests/immutability.test.ts` from #71)
- `npx tsc --noEmit` — clean
- `npm run build` — clean

## Files changed
- `src/index.ts` — JSDoc only, no behavior change beyond what #71 already introduced
- `README.md` — new breaking-change warning entry